### PR TITLE
Add option in readme to fix issue on cluster.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,13 @@ sudo singularity build singularity.sif singularity.def
 ```
 
 ```carveme_2.def``` is another version of the image starting directly from the *ibmjava:latest* docker image
+
+If you have issue when using the container on a cluster, you can try these options:
+
+```sh
+singularity run -c -B /folder/cluster/:/folder/cluster/ /folder/cluster/carveme.sif carve /folder/cluster/input_folder/data.faa
+```
+
+The ``-B`` option gives access to the Singularity container to a specific path. The first path corresponds to the local/cluster path and the second path (after the ``:``) corresponds to the path inside the Singularity container. Using this option can solved issue with error message ``Unable to create output folder: /folder/cluster/input_folder`` (because the Singularity container has no right to create output files in the folder).
+
+The ``-c`` option runs the Singularity image in an isolated manner with a minimal /dev and empty other directories (e.g. /tmp and $HOME) instead of sharing filesystems from your host. This avoids issue with environment present in the cluster. Using this option can solved issue with error message ``Segmentation fault`` after Diamond.


### PR DESCRIPTION
When using the Singularity container created by ```carveme_2.def```, it is possible to encounter two issues on a cluster:

- ``Unable to create output folder: /folder/cluster/input_folder``: Singularity has no right to write output files and folder. This is fixed by using the option ``-B`` and giving access to the folder.

- ``Segmentation fault`` after Diamond run: There is possible environment conflict, the ``-c`` will isolate the singularity container and fixed the issue.