### PR TITLE
Fix issue with tmp folder and singularity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # carveme_singularity
-Singularity image definition to install [IBM Cplex](https://www.ibm.com/analytics/cplex-optimizer) and [Carveme](https://github.com/cdanielmachado/carveme) in a container (e.g. for using the software on a cluster)
+Singularity image definition to install [IBM Cplex](https://www.ibm.com/analytics/cplex-optimizer) and [Carveme](https://github.com/cdanielmachado/carveme) in a container (e.g. for using the software on a cluster).
 
 ## Installation
 The binary file of Cplex (under license) has to be located in the same directory as the definition file. 
@@ -20,7 +20,7 @@ The image is build with the following command:
 sudo singularity build singularity.sif singularity.def
 ```
 
-```carveme_2.def``` is another version of the image starting directly from the *ibmjava:latest* docker image. It has been tested with cplex 12.8 and 12.10. At this moment it is the only one updated.
+```carveme_2.def``` is another version of the image starting directly from the *ibmjava:latest* docker image. It has been tested with cplex 12.8 and 12.10. At this moment it is the only one updated. The size of the container file is around 1.8 Gb.
 
 If you have issue when using the container on a cluster, you can try these options:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # carveme_singularity
-SIngularity image definition to install Cplex and Carveme in a container (e.g. for using the software on a cluster)
+Singularity image definition to install [IBM Cplex](https://www.ibm.com/analytics/cplex-optimizer) and [Carveme](https://github.com/cdanielmachado/carveme) in a container (e.g. for using the software on a cluster)
 
 ## Installation
 The binary file of Cplex (under license) has to be located in the same directory as the definition file. 
@@ -20,7 +20,7 @@ The image is build with the following command:
 sudo singularity build singularity.sif singularity.def
 ```
 
-```carveme_2.def``` is another version of the image starting directly from the *ibmjava:latest* docker image
+```carveme_2.def``` is another version of the image starting directly from the *ibmjava:latest* docker image. It has been tested with cplex 12.8 and 12.10. At this moment it is the only one updated.
 
 If you have issue when using the container on a cluster, you can try these options:
 

--- a/carveme_2.def
+++ b/carveme_2.def
@@ -2,7 +2,7 @@ Bootstrap: docker
 From: ibmjava:latest
 
 %files
-     cplex_studio128.linux-x86-64.bin /tmp
+     cplex_studio128.linux-x86-64.bin /opt
 
 %environment
      export PATH=$PATH:/programs
@@ -28,7 +28,7 @@ From: ibmjava:latest
      sed -ri 's/^PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config ;\
      sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config ;\
      mkdir programs ;\
-     cd /tmp ;\
+     cd /opt ;\
      wget http://github.com/bbuchfink/diamond/releases/download/v0.9.26/diamond-linux64.tar.gz ;\
      tar xzf diamond-linux64.tar.gz ;\
      cp diamond /programs ;\

--- a/carveme_2.def
+++ b/carveme_2.def
@@ -40,6 +40,7 @@ From: ibmjava:latest
      export PATH=$PATH:/opt/ibm/java/jre/bin/
      chmod +x cplex_studio128.linux-x86-64.bin ;\
      printf '4\n\n1\n\n\n\n\n' | ./cplex_studio128.linux-x86-64.bin ;\
+     #printf '4\n\n1\n\n\n\n\n2\n\n' | ./cplex_studio1210.linux-x86-64.bin ;\
      cd /opt/ibm/ILOG/CPLEX_Studio128/python/ ;\
      python3 setup.py install ;\
      cd ;\

--- a/carveme_2.def
+++ b/carveme_2.def
@@ -40,8 +40,8 @@ From: ibmjava:latest
      export PATH=$PATH:/opt/ibm/java/jre/bin/
      chmod +x cplex_studio128.linux-x86-64.bin ;\
      printf '4\n\n1\n\n\n\n\n' | ./cplex_studio128.linux-x86-64.bin ;\
+     # Use the following line for cplex 12.10 (and replaces iteration of '128' with '1210'):
      #printf '4\n\n1\n\n\n\n\n2\n\n' | ./cplex_studio1210.linux-x86-64.bin ;\
      cd /opt/ibm/ILOG/CPLEX_Studio128/python/ ;\
      python3 setup.py install ;\
-     cd ;\
-     python3 -c 'from carveme.cli.carve import first_run_check; first_run_check()' ;\
+     python3 -c 'from carveme.cli.carve import first_run_check; first_run_check()'

--- a/carveme_2.def
+++ b/carveme_2.def
@@ -29,11 +29,11 @@ From: ibmjava:latest
      sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config ;\
      mkdir programs ;\
      cd /opt ;\
-     wget http://github.com/bbuchfink/diamond/releases/download/v0.9.26/diamond-linux64.tar.gz ;\
+     wget https://github.com/bbuchfink/diamond/releases/download/v2.0.11/diamond-linux64.tar.gz ;\
      tar xzf diamond-linux64.tar.gz ;\
      cp diamond /programs ;\
      curl https://bootstrap.pypa.io/get-pip.py | python3 ;\
-     pip install pandas==0.24 ;\
+     pip install pandas>=1.0 reframed>=1.2.1;\
      pip install carveme ;\
      pip install future ;\
      export PATH=$PATH:/programs


### PR DESCRIPTION
The `/tmp` is no more accessible during build and it poduces  an error with Singularity version >= 3.6. By moving to the `/opt` folder it seems to fix the issue.