### PR TITLE
Fix issue with get-pip.py incompatibility with Python 3.6.

### DIFF
--- a/carveme_2.def
+++ b/carveme_2.def
@@ -32,7 +32,7 @@ From: ibmjava:latest
      wget https://github.com/bbuchfink/diamond/releases/download/v2.0.11/diamond-linux64.tar.gz ;\
      tar xzf diamond-linux64.tar.gz ;\
      cp diamond /programs ;\
-     curl https://bootstrap.pypa.io/get-pip.py | python3 ;\
+     curl https://bootstrap.pypa.io/pip/3.6/get-pip.py | python3 ;\
      pip install pandas>=1.0 reframed>=1.2.1;\
      pip install carveme ;\
      pip install future ;\


### PR DESCRIPTION
Hi,

The script [get-pip.py](https://bootstrap.pypa.io/get-pip.py) that is used to install pip is no more compatible with Python 3.6 (now it requires Python 3.7).

So the Python 3.6 compatible version should be used instead:

https://bootstrap.pypa.io/pip/3.6/get-pip.py

This commit should fix the issue.